### PR TITLE
バリデーション追加　ユーザーが同日付の作成不可

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -7,7 +7,7 @@ use App\Http\Requests\StoreChart;
 use Illuminate\Support\Facades\Auth;
 use App\Note;
 use Carbon\Carbon;
-
+use phpDocumentor\Reflection\Types\Null_;
 
 class NoteController extends Controller
 {
@@ -22,11 +22,12 @@ class NoteController extends Controller
      */
     public function index()
     {
+
         $user_id = Auth::id();
         //$notes = Note::with(['user'])->orderBy(Note::CREATED_AT, 'desc')->paginate();
         $len = Note::where('user_id',$user_id)->orderBy('record', 'asc')->count();
-
         $notes = Note::where('user_id',$user_id)->orderBy('record', 'asc')->paginate($len);
+
         return $notes;
     }
 
@@ -38,9 +39,7 @@ class NoteController extends Controller
     }
 
     public function create(StoreNote $request){
-
         $note = new Note();
-
         $note->record = $request->record; //日付取得
         $note->wake_uptime = $request->wake_uptime; //起床時間の取得
         $note->bedtime = $request->bedtime; //就寝時間の取得
@@ -48,12 +47,11 @@ class NoteController extends Controller
         $note->pm_image = $request->iconId_2; //午後の調子値
         $note->night_image = $request->iconId_3; //夜の調子値
         $note->body = $request->body; //テキスト取得
-        //$note->bedtime = $request->bedtime; 画像データ取得
         $note->user_id = $request->user()->id;
 
         $note->save();
-
         return response($note, 201);
+
     }
 
     public function update(Request $request, $id){

--- a/app/Http/Requests/StoreNote.php
+++ b/app/Http/Requests/StoreNote.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Auth;
+use App\Note;
 
 class StoreNote extends FormRequest
 {
@@ -26,16 +27,14 @@ class StoreNote extends FormRequest
      */
     public function rules()
     {
-         // ログインしているユーザーIDを取得
-        $user_id = Auth::id();
+        //$record = Note::where('user_id',$user_id)->where('record', $this->record)->exists();
         return [
             'record' => [
                 'required',
-                'unique:notes',
-                //Rule::unique('notes')->where('user_id',$user_id)
-                Rule::unique('notes', 'user_id')
-                    ->ignore($user_id, 'user_id'),
-
+                Rule::unique('notes')->where(function ($query) {
+                    $user_id = Auth::id();
+                    return $query->where('user_id',$user_id)->where('record', $this->record);
+                })
             ],
             'wake_uptime' => 'required',
             'bedtime' => 'required',


### PR DESCRIPTION
ログインユーザーで同じ日付でnoteが作成できていたので、異なるユーザーでは作成可能だが、ログインユーザーでは
同じ日付でnote投稿ができないようにバリデーションを追加した。